### PR TITLE
Compiler Error Wrap-up

### DIFF
--- a/byond-extools/src/core/byond_functions.h
+++ b/byond-extools/src/core/byond_functions.h
@@ -76,7 +76,7 @@ typedef void(*ProcCleanupPtr)(ExecutionContext* thing_that_just_executed); //thi
 typedef void(REGPARM3 *CreateContextPtr)(void* unknown, ExecutionContext* new_ctx);
 typedef void(REGPARM3 *ProcCleanupPtr)(ExecutionContext* thing_that_just_executed);
 #endif
-typedef void(*RuntimePtr)(char* error); //Do not call this, it relies on some global state
+typedef void(*RuntimePtr)(const char* error); //Do not call this, it relies on some global state
 typedef trvh(*GetTurfPtr)(int x, int y, int z);
 typedef unsigned int(*LengthPtr)(int type, int value);
 typedef bool(*IsInContainerPtr)(int keyType, int keyValue, int cntType, int cntId);

--- a/byond-extools/src/core/byond_structures.cpp
+++ b/byond-extools/src/core/byond_structures.cpp
@@ -317,7 +317,7 @@ ManagedValue::ManagedValue(ManagedValue&& other) noexcept
 	IncRefCount(type, value);
 }
 
-ManagedValue& ManagedValue::operator =(ManagedValue& other)
+ManagedValue& ManagedValue::operator =(const ManagedValue& other)
 {
 	DecRefCount(type, value);
 	type = other.type;

--- a/byond-extools/src/core/byond_structures.h
+++ b/byond-extools/src/core/byond_structures.h
@@ -146,7 +146,7 @@ struct ManagedValue : Value
 	ManagedValue(std::string s);
 	ManagedValue(const ManagedValue& other);
 	ManagedValue(ManagedValue&& other) noexcept;
-	ManagedValue& operator =(ManagedValue& other);
+	ManagedValue& operator =(const ManagedValue& other);
 	~ManagedValue();
 };
 

--- a/byond-extools/src/crash_guard/crash_guard.cpp
+++ b/byond-extools/src/crash_guard/crash_guard.cpp
@@ -119,7 +119,7 @@ void dump_oor()
 	} while (ctx = ctx->parent_context);
 }
 
-void hRuntimeLL(char* err)
+void hRuntimeLL(const char* err)
 {
 	if (strcmp(err, "Out of resources!") == 0)
 	{

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -403,7 +403,7 @@ void DebugServer::on_break(ExecutionContext* ctx)
 	}
 }
 
-void DebugServer::on_error(ExecutionContext* ctx, char* error)
+void DebugServer::on_error(ExecutionContext* ctx, const char* error)
 {
 	Core::Proc& p = Core::get_proc(ctx);
 	send_call_stack(ctx);
@@ -524,7 +524,7 @@ void on_nop(ExecutionContext* ctx)
 
 }
 
-void hRuntime(char* error)
+void hRuntime(const char* error)
 {
 	if (debug_server.break_on_runtimes)
 	{

--- a/byond-extools/src/debug_server/debug_server.h
+++ b/byond-extools/src/debug_server/debug_server.h
@@ -89,7 +89,7 @@ public:
 
 	NextAction wait_for_action();
 
-	void on_error(ExecutionContext* ctx, char* error);
+	void on_error(ExecutionContext* ctx, const char* error);
 	void on_breakpoint(ExecutionContext* ctx);
 	void on_step(ExecutionContext* ctx);
 	void on_break(ExecutionContext* ctx);

--- a/byond-extools/src/monstermos/GasMixture.cpp
+++ b/byond-extools/src/monstermos/GasMixture.cpp
@@ -1,6 +1,10 @@
 #include "GasMixture.h"
+
+#include <algorithm>
 #include <cstring>
 #include <cmath>
+
+using namespace monstermos::constants;
 
 float gas_specific_heat[TOTAL_NUM_GASES];
 
@@ -22,7 +26,7 @@ float GasMixture::heat_capacity() const {
     for(int i = 0; i < TOTAL_NUM_GASES; i++) {
         capacity += (gas_specific_heat[i] * moles[i]);
     }
-    return std::fmax(capacity, min_heat_capacity);
+    return std::max(capacity, min_heat_capacity);
 }
 
 float GasMixture::heat_capacity_archived() const {
@@ -30,7 +34,7 @@ float GasMixture::heat_capacity_archived() const {
     for(int i = 0; i < TOTAL_NUM_GASES; i++) {
         capacity += (gas_specific_heat[i] * moles_archived[i]);
     }
-    return std::fmax(capacity, min_heat_capacity);
+    return std::max(capacity, min_heat_capacity);
 }
 
 void GasMixture::set_min_heat_capacity(float n) {
@@ -169,9 +173,9 @@ void GasMixture::temperature_share(GasMixture &sharer, float conduction_coeffici
         if((sharer_heat_capacity > MINIMUM_HEAT_CAPACITY) && (self_heat_capacity > MINIMUM_HEAT_CAPACITY)) {
             float heat = conduction_coefficient * temperature_delta * (self_heat_capacity*sharer_heat_capacity/(self_heat_capacity+sharer_heat_capacity));
             if(!immutable)
-                temperature = fmax(temperature - heat/self_heat_capacity, TCMB);
+                temperature = std::max(temperature - heat/self_heat_capacity, TCMB);
             if(!sharer.immutable)
-                sharer.temperature = fmax(sharer.temperature + heat/sharer_heat_capacity, TCMB);
+                sharer.temperature = std::max(sharer.temperature + heat/sharer_heat_capacity, TCMB);
         }
     }
 }

--- a/byond-extools/src/monstermos/atmos_defines.h
+++ b/byond-extools/src/monstermos/atmos_defines.h
@@ -1,133 +1,139 @@
 #pragma once
 
+namespace monstermos::constants
+{
+
 //ATMOS
 //stuff you should probably leave well alone!
-#define R_IDEAL_GAS_EQUATION	8.31	//kPa*L/(K*mol)
-#define ONE_ATMOSPHERE			101.325	//kPa
-#define TCMB					2.7		// -270.3degC
-#define TCRYO					225		// -48.15degC
-#define T0C						273.15	// 0degC
-#define T20C					293.15	// 20degC
+const float R_IDEAL_GAS_EQUATION = 8.31;	//kPa*L/(K*mol)
+const float ONE_ATMOSPHERE       = 101.325;	//kPa
+const float TCMB                 = 2.7;		// -270.3degC
+const float TCRYO                = 225;		// -48.15degC
+const float T0C	                 = 273.15;	// 0degC
+const float T20C                 = 293.15;	// 20degC
 
-#define MOLES_CELLSTANDARD		(ONE_ATMOSPHERE*CELL_VOLUME/(T20C*R_IDEAL_GAS_EQUATION))	//moles in a 2.5 m^3 cell at 101.325 Pa and 20 degC
-#define M_CELL_WITH_RATIO		(MOLES_CELLSTANDARD * 0.005) //compared against for superconductivity
-#define O2STANDARD				0.21	//percentage of oxygen in a normal mixture of air
-#define N2STANDARD				0.79	//same but for nitrogen
-#define MOLES_O2STANDARD		(MOLES_CELLSTANDARD*O2STANDARD)	// O2 standard value (21%)
-#define MOLES_N2STANDARD		(MOLES_CELLSTANDARD*N2STANDARD)	// N2 standard value (79%)
-#define CELL_VOLUME				2500.0	//liters in a cell
-#define BREATH_VOLUME			0.5		//liters in a normal breath
-#define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)					//Amount of air to take a from a tile
+const float CELL_VOLUME				= 2500.0;	//liters in a cell
+const float MOLES_CELLSTANDARD		= (ONE_ATMOSPHERE*CELL_VOLUME/(T20C*R_IDEAL_GAS_EQUATION));	//moles in a 2.5 m^3 cell at 101.325 Pa and 20 degC
+const float M_CELL_WITH_RATIO		= (MOLES_CELLSTANDARD * 0.005); //compared against for superconductivity
+const float O2STANDARD				= 0.21;	//percentage of oxygen in a normal mixture of air
+const float N2STANDARD				= 0.79;	//same but for nitrogen
+const float MOLES_O2STANDARD		= (MOLES_CELLSTANDARD*O2STANDARD);	// O2 standard value (21%)
+const float MOLES_N2STANDARD		= (MOLES_CELLSTANDARD*N2STANDARD);	// N2 standard value (79%)
+const float BREATH_VOLUME			= 0.5;		//liters in a normal breath
+const float BREATH_PERCENTAGE		= (BREATH_VOLUME/CELL_VOLUME);					//Amount of air to take a from a tile
 
 //EXCITED GROUPS
-#define EXCITED_GROUP_BREAKDOWN_CYCLES				4		//number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)
-#define EXCITED_GROUP_DISMANTLE_CYCLES				16		//number of FULL air controller ticks before an excited group dismantles and removes its turfs from active
-#define MINIMUM_AIR_RATIO_TO_SUSPEND				0.1		//Ratio of air that must move to/from a tile to reset group processing
-#define MINIMUM_AIR_RATIO_TO_MOVE					0.001	//Minimum ratio of air that must move to/from a tile
-#define MINIMUM_AIR_TO_SUSPEND						(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND)	//Minimum amount of air that has to move before a group processing can be suspended
-#define MINIMUM_MOLES_DELTA_TO_MOVE					(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_MOVE) //Either this must be active
-#define MINIMUM_TEMPERATURE_TO_MOVE					(T20C+100.0)			//or this (or both, obviously)
-#define MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND		4.0		//Minimum temperature difference before group processing is suspended
-#define MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER		0.5		//Minimum temperature difference before the gas temperatures are just set to be equal
-#define MINIMUM_TEMPERATURE_FOR_SUPERCONDUCTION		(T20C+10.0)
-#define MINIMUM_TEMPERATURE_START_SUPERCONDUCTION	(T20C+200.0)
+const int EXCITED_GROUP_BREAKDOWN_CYCLES				= 4;		//number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)
+const int EXCITED_GROUP_DISMANTLE_CYCLES				= 16;		//number of FULL air controller ticks before an excited group dismantles and removes its turfs from active
+
+const float MINIMUM_AIR_RATIO_TO_SUSPEND				= 0.1;		//Ratio of air that must move to/from a tile to reset group processing
+const float MINIMUM_AIR_RATIO_TO_MOVE					= 0.001;	//Minimum ratio of air that must move to/from a tile
+const float MINIMUM_AIR_TO_SUSPEND						= (MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND);	//Minimum amount of air that has to move before a group processing can be suspended
+const float MINIMUM_MOLES_DELTA_TO_MOVE					= (MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_MOVE); //Either this must be active
+const float MINIMUM_TEMPERATURE_TO_MOVE					= (T20C+100.0);			//or this (or both, obviously)
+const float MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND		= 4.0;		//Minimum temperature difference before group processing is suspended
+const float MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER		= 0.5;		//Minimum temperature difference before the gas temperatures are just set to be equal
+const float MINIMUM_TEMPERATURE_FOR_SUPERCONDUCTION		= (T20C+10.0);
+const float MINIMUM_TEMPERATURE_START_SUPERCONDUCTION	= (T20C+200.0);
 
 //HEAT TRANSFER COEFFICIENTS
 //Must be between 0 and 1. Values closer to 1 equalize temperature faster
 //Should not exceed 0.4 else strange heat flow occur
-#define WALL_HEAT_TRANSFER_COEFFICIENT		0.0
-#define OPEN_HEAT_TRANSFER_COEFFICIENT		0.4
-#define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1		//a hack for now
-#define HEAT_CAPACITY_VACUUM				7000.0	//a hack to help make vacuums "cold", sacrificing realism for gameplay
+const float WALL_HEAT_TRANSFER_COEFFICIENT		= 0.0;
+const float OPEN_HEAT_TRANSFER_COEFFICIENT		= 0.4;
+const float WINDOW_HEAT_TRANSFER_COEFFICIENT	= 0.1;		//a hack for now
+const float HEAT_CAPACITY_VACUUM				= 7000.0;	//a hack to help make vacuums "cold", sacrificing realism for gameplay
 
 //FIRE
-#define FIRE_MINIMUM_TEMPERATURE_TO_SPREAD	(150.0+T0C)
-#define FIRE_MINIMUM_TEMPERATURE_TO_EXIST	(100.0+T0C)
-#define FIRE_SPREAD_RADIOSITY_SCALE			0.85
-#define FIRE_GROWTH_RATE					40000	//For small fires
-#define PLASMA_MINIMUM_BURN_TEMPERATURE		(100.0+T0C)
-#define PLASMA_UPPER_TEMPERATURE			(1370.0+T0C)
-#define PLASMA_OXYGEN_FULLBURN				10
+const float FIRE_MINIMUM_TEMPERATURE_TO_SPREAD	= (150.0+T0C);
+const float FIRE_MINIMUM_TEMPERATURE_TO_EXIST	= (100.0+T0C);
+const float FIRE_SPREAD_RADIOSITY_SCALE			= 0.85;
+const float FIRE_GROWTH_RATE					= 40000;	//For small fires
+const float PLASMA_MINIMUM_BURN_TEMPERATURE		= (100.0+T0C);
+const float PLASMA_UPPER_TEMPERATURE			= (1370.0+T0C);
+const float PLASMA_OXYGEN_FULLBURN				= 10;
 
 //GASES
-#define MIN_TOXIC_GAS_DAMAGE				1
-#define MAX_TOXIC_GAS_DAMAGE				10
-#define MOLES_GAS_VISIBLE					0.25	//Moles in a standard cell after which gases are visible
+const int MIN_TOXIC_GAS_DAMAGE				= 1;
+const int MAX_TOXIC_GAS_DAMAGE				= 10;
+const float MOLES_GAS_VISIBLE				= 0.25;	//Moles in a standard cell after which gases are visible
 
-#define FACTOR_GAS_VISIBLE_MAX				20 //moles_visible * FACTOR_GAS_VISIBLE_MAX = Moles after which gas is at maximum visibility
-#define MOLES_GAS_VISIBLE_STEP				0.25 //Mole step for alpha updates. This means alpha can update at 0.25, 0.5, 0.75 and so on
+const float FACTOR_GAS_VISIBLE_MAX				= 20; //moles_visible * FACTOR_GAS_VISIBLE_MAX = Moles after which gas is at maximum visibility
+const float MOLES_GAS_VISIBLE_STEP				= 0.25; //Mole step for alpha updates. This means alpha can update at 0.25, 0.5, 0.75 and so on
 
 //REACTIONS
 //return values for reactions (bitflags)
-#define NO_REACTION		0
-#define REACTING		1
-#define STOP_REACTIONS 	2
+const int NO_REACTION       = 0;
+const int REACTING          = 1;
+const int STOP_REACTIONS    = 2;
 
 // Pressure limits.
-#define HAZARD_HIGH_PRESSURE				550		//This determins at what pressure the ultra-high pressure red icon is displayed. (This one is set as a constant)
-#define WARNING_HIGH_PRESSURE				325		//This determins when the orange pressure icon is displayed (it is 0.7 * HAZARD_HIGH_PRESSURE)
-#define WARNING_LOW_PRESSURE				50		//This is when the gray low pressure icon is displayed. (it is 2.5 * HAZARD_LOW_PRESSURE)
-#define HAZARD_LOW_PRESSURE					20		//This is when the black ultra-low pressure icon is displayed. (This one is set as a constant)
+const float HAZARD_HIGH_PRESSURE				= 550;		//This determins at what pressure the ultra-high pressure red icon is displayed. (This one is set as a constant)
+const float WARNING_HIGH_PRESSURE				= 325;		//This determins when the orange pressure icon is displayed (it is 0.7 * HAZARD_HIGH_PRESSURE)
+const float WARNING_LOW_PRESSURE				= 50;		//This is when the gray low pressure icon is displayed. (it is 2.5 * HAZARD_LOW_PRESSURE)
+const float HAZARD_LOW_PRESSURE					= 20;		//This is when the black ultra-low pressure icon is displayed. (This one is set as a constant)
 
-#define TEMPERATURE_DAMAGE_COEFFICIENT		1.5		//This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
+const float TEMPERATURE_DAMAGE_COEFFICIENT		= 1.5;		//This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
 
-#define BODYTEMP_NORMAL						310.15			//The natural temperature for a body
-#define BODYTEMP_AUTORECOVERY_DIVISOR		11		//This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
-#define BODYTEMP_AUTORECOVERY_MINIMUM		12		//Minimum amount of kelvin moved toward 310K per tick. So long as abs(310.15 - bodytemp) is more than 50.
-#define BODYTEMP_COLD_DIVISOR				6		//Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
-#define BODYTEMP_HEAT_DIVISOR				15		//Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.
-#define BODYTEMP_COOLING_MAX				-100		//The maximum number of degrees that your body can cool in 1 tick, due to the environment, when in a cold area.
-#define BODYTEMP_HEATING_MAX				30		//The maximum number of degrees that your body can heat up in 1 tick, due to the environment, when in a hot area.
+const float BODYTEMP_NORMAL						= 310.15;			//The natural temperature for a body
+const float BODYTEMP_AUTORECOVERY_DIVISOR		= 11;		//This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
+const float BODYTEMP_AUTORECOVERY_MINIMUM		= 12;		//Minimum amount of kelvin moved toward 310K per tick. So long as abs(310.15 - bodytemp) is more than 50.
+const float BODYTEMP_COLD_DIVISOR				= 6;		//Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
+const float BODYTEMP_HEAT_DIVISOR				= 15;		//Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.
+const float BODYTEMP_COOLING_MAX				= -100;		//The maximum number of degrees that your body can cool in 1 tick, due to the environment, when in a cold area.
+const float BODYTEMP_HEATING_MAX				= 30;		//The maximum number of degrees that your body can heat up in 1 tick, due to the environment, when in a hot area.
 
-#define BODYTEMP_HEAT_DAMAGE_LIMIT			(BODYTEMP_NORMAL + 50) // The limit the human body can take before it starts taking damage from heat.
-#define BODYTEMP_COLD_DAMAGE_LIMIT			(BODYTEMP_NORMAL - 50) // The limit the human body can take before it starts taking damage from coldness.
+const float BODYTEMP_HEAT_DAMAGE_LIMIT			= (BODYTEMP_NORMAL + 50); // The limit the human body can take before it starts taking damage from heat.
+const float BODYTEMP_COLD_DAMAGE_LIMIT			= (BODYTEMP_NORMAL - 50); // The limit the human body can take before it starts taking damage from coldness.
 
 
-#define SPACE_HELM_MIN_TEMP_PROTECT			2.0		//what min_cold_protection_temperature is set to for space-helmet quality headwear. MUST NOT BE 0.
-#define SPACE_HELM_MAX_TEMP_PROTECT			1500	//Thermal insulation works both ways /Malkevin
-#define SPACE_SUIT_MIN_TEMP_PROTECT			2.0		//what min_cold_protection_temperature is set to for space-suit quality jumpsuits or suits. MUST NOT BE 0.
-#define SPACE_SUIT_MAX_TEMP_PROTECT			1500
+const float SPACE_HELM_MIN_TEMP_PROTECT			= 2.0;		//what min_cold_protection_temperature is set to for space-helmet quality headwear. MUST NOT BE 0.
+const float SPACE_HELM_MAX_TEMP_PROTECT			= 1500;	//Thermal insulation works both ways /Malkevin
+const float SPACE_SUIT_MIN_TEMP_PROTECT			= 2.0;		//what min_cold_protection_temperature is set to for space-suit quality jumpsuits or suits. MUST NOT BE 0.
+const float SPACE_SUIT_MAX_TEMP_PROTECT			= 1500;
 
-#define FIRE_SUIT_MIN_TEMP_PROTECT			60		//Cold protection for firesuits
-#define FIRE_SUIT_MAX_TEMP_PROTECT			30000	//what max_heat_protection_temperature is set to for firesuit quality suits. MUST NOT BE 0.
-#define FIRE_HELM_MIN_TEMP_PROTECT			60		//Cold protection for fire helmets
-#define FIRE_HELM_MAX_TEMP_PROTECT			30000	//for fire helmet quality items (red and white hardhats)
+const float FIRE_SUIT_MIN_TEMP_PROTECT			= 60;		//Cold protection for firesuits
+const float FIRE_SUIT_MAX_TEMP_PROTECT			= 30000;	//what max_heat_protection_temperature is set to for firesuit quality suits. MUST NOT BE 0.
+const float FIRE_HELM_MIN_TEMP_PROTECT			= 60;		//Cold protection for fire helmets
+const float FIRE_HELM_MAX_TEMP_PROTECT			= 30000;	//for fire helmet quality items (red and white hardhats)
 
-#define FIRE_IMMUNITY_MAX_TEMP_PROTECT	35000		//what max_heat_protection_temperature is set to for firesuit quality suits and helmets. MUST NOT BE 0.
+const float FIRE_IMMUNITY_MAX_TEMP_PROTECT	 = 35000;		//what max_heat_protection_temperature is set to for firesuit quality suits and helmets. MUST NOT BE 0.
 
-#define HELMET_MIN_TEMP_PROTECT				160		//For normal helmets
-#define HELMET_MAX_TEMP_PROTECT				600		//For normal helmets
-#define ARMOR_MIN_TEMP_PROTECT				160		//For armor
-#define ARMOR_MAX_TEMP_PROTECT				600		//For armor
+const float HELMET_MIN_TEMP_PROTECT				= 160;		//For normal helmets
+const float HELMET_MAX_TEMP_PROTECT				= 600;		//For normal helmets
+const float ARMOR_MIN_TEMP_PROTECT				= 160;		//For armor
+const float ARMOR_MAX_TEMP_PROTECT				= 600;		//For armor
 
-#define GLOVES_MIN_TEMP_PROTECT				2.0		//For some gloves (black and)
-#define GLOVES_MAX_TEMP_PROTECT				1500	//For some gloves
-#define SHOES_MIN_TEMP_PROTECT				2.0		//For gloves
-#define SHOES_MAX_TEMP_PROTECT				1500	//For gloves
+const float GLOVES_MIN_TEMP_PROTECT				= 2.0;		//For some gloves (black and)
+const float GLOVES_MAX_TEMP_PROTECT				= 1500;	//For some gloves
+const float SHOES_MIN_TEMP_PROTECT				= 2.0;		//For gloves
+const float SHOES_MAX_TEMP_PROTECT				= 1500;	//For gloves
 
-#define PRESSURE_DAMAGE_COEFFICIENT			4		//The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT, with the maximum of MAX_PRESSURE_DAMAGE
-#define MAX_HIGH_PRESSURE_DAMAGE			4
-#define LOW_PRESSURE_DAMAGE					4		//The amount of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
+const float PRESSURE_DAMAGE_COEFFICIENT			= 4;		//The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT, with the maximum of MAX_PRESSURE_DAMAGE
+const float MAX_HIGH_PRESSURE_DAMAGE			= 4;
+const float LOW_PRESSURE_DAMAGE					= 4;		//The amount of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
 
-#define COLD_SLOWDOWN_FACTOR				20		//Humans are slowed by the difference between bodytemp and BODYTEMP_COLD_DAMAGE_LIMIT divided by this
+const float COLD_SLOWDOWN_FACTOR				= 20;		//Humans are slowed by the difference between bodytemp and BODYTEMP_COLD_DAMAGE_LIMIT divided by this
 
 //PIPES
 //Atmos pipe limits
-#define MAX_OUTPUT_PRESSURE					4500 // (kPa) What pressure pumps and powered equipment max out at.
-#define MAX_TRANSFER_RATE					200 // (L/s) Maximum speed powered equipment can work at.
-#define VOLUME_PUMP_LEAK_AMOUNT				0.1 //10% of an overclocked volume pump leaks into the air
+const float MAX_OUTPUT_PRESSURE					= 4500; // (kPa) What pressure pumps and powered equipment max out at.
+const float MAX_TRANSFER_RATE					= 200; // (L/s) Maximum speed powered equipment can work at.
+const float VOLUME_PUMP_LEAK_AMOUNT				= 0.1; //10% of an overclocked volume pump leaks into the air
 //used for device_type vars
-#define UNARY		1
-#define BINARY 		2
-#define TRINARY		3
-#define QUATERNARY	4
+const int UNARY         = 1;
+const int BINARY        = 2;
+const int TRINARY       = 3;
+const int QUATERNARY    = 4;
 
 //TANKS
-#define TANK_MELT_TEMPERATURE				1000000	//temperature in kelvins at which a tank will start to melt
-#define TANK_LEAK_PRESSURE					(30.*ONE_ATMOSPHERE)	//Tank starts leaking
-#define TANK_RUPTURE_PRESSURE				(35.*ONE_ATMOSPHERE)	//Tank spills all contents into atmosphere
-#define TANK_FRAGMENT_PRESSURE				(40.*ONE_ATMOSPHERE)	//Boom 3x3 base explosion
-#define TANK_FRAGMENT_SCALE	    			(6.*ONE_ATMOSPHERE)		//+1 for each SCALE kPa aboe threshold
-#define TANK_MAX_RELEASE_PRESSURE 			(ONE_ATMOSPHERE*3)
-#define TANK_MIN_RELEASE_PRESSURE 			0
-#define TANK_DEFAULT_RELEASE_PRESSURE 		16
+const float TANK_MELT_TEMPERATURE				= 1000000;	//temperature in kelvins at which a tank will start to melt
+const float TANK_LEAK_PRESSURE					= (30.*ONE_ATMOSPHERE);	//Tank starts leaking
+const float TANK_RUPTURE_PRESSURE				= (35.*ONE_ATMOSPHERE);	//Tank spills all contents into atmosphere
+const float TANK_FRAGMENT_PRESSURE				= (40.*ONE_ATMOSPHERE);	//Boom 3x3 base explosion
+const float TANK_FRAGMENT_SCALE	    			= (6.*ONE_ATMOSPHERE);		//+1 for each SCALE kPa aboe threshold
+const float TANK_MAX_RELEASE_PRESSURE 			= (ONE_ATMOSPHERE*3);
+const float TANK_MIN_RELEASE_PRESSURE 			= 0;
+const float TANK_DEFAULT_RELEASE_PRESSURE 		= 16;
+
+}

--- a/byond-extools/src/monstermos/monstermos.cpp
+++ b/byond-extools/src/monstermos/monstermos.cpp
@@ -1,9 +1,14 @@
 #include "monstermos.h"
+
 #include "../core/core.h"
 #include "GasMixture.h"
 #include "turf_grid.h"
 #include "../dmdism/opcodes.h"
+
+#include <cmath>
 #include <chrono>
+
+using namespace monstermos::constants;
 
 trvh fuck(unsigned int args_len, Value* args, Value src)
 {
@@ -180,7 +185,7 @@ trvh gasmixture_get_gases(unsigned int args_len, Value* args, Value src)
 trvh gasmixture_set_temperature(unsigned int args_len, Value* args, Value src)
 {
 	float vf = args_len > 0 ? args[0].valuef : 0;
-	if (isnan(vf) || isinf(vf)) {
+	if (std::isnan(vf) || std::isinf(vf)) {
 		Runtime("Attempt to set temperature to NaN or Infinity");
 	} else {
 		get_gas_mixture(src)->set_temperature(vf);

--- a/byond-extools/src/monstermos/turf_grid.cpp
+++ b/byond-extools/src/monstermos/turf_grid.cpp
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <cstring>
 
+using namespace monstermos::constants;
+
 Tile::Tile()
 {
     //ctor

--- a/byond-extools/src/monstermos/turf_grid.h
+++ b/byond-extools/src/monstermos/turf_grid.h
@@ -41,7 +41,7 @@ struct Tile
 struct PlanetAtmosInfo
 {
 	ManagedValue last_initial = Value::Null();
-	GasMixture last_mix = GasMixture(CELL_VOLUME);
+	GasMixture last_mix = GasMixture(monstermos::constants::CELL_VOLUME);
 }; // not part of main Tile struct because we don't need it for the whole map
 
 struct MonstermosInfo


### PR DESCRIPTION
GCC adheres to the standard in a manner more strict than MSVCC so it threw a few errors at me when I was compiling it with GCC 9.

Changes done:

- Refactor _most_ of the constants into actual constants. This is important for two reasons: first, we're writing C++ and the compiler has a better handle on a `const` than a define when it comes to optimizing; second, because it's type-safe. Every single decimal number in the defines atm. was a `double`, which resulted in operand promotion during computation aaand in template methods like `std::abs` not working, because one operand wasn't necessarily a `float`. They're secreted away under `monstermos::constants` namespace for future use of namespaces.
- Refactor the usage of cmath functions like `isnan` to use the correctly namespaced ones. Along with a use of `abs` over `std::abs`.
- Remove UB and standard compliance warnings from using `Runtime()`. It's UB to cast a `const char*` (compile-time string literal) to a `char*` in C++11 and up.
- Fixed a compile error on GCC 9 stemming from what I _think_ was copy-elision in the `ManagedValue::operator=` function call somewhere in monstermos.